### PR TITLE
Overload the timezone format for local mean time

### DIFF
--- a/test/time_zone_database_test.exs
+++ b/test/time_zone_database_test.exs
@@ -88,6 +88,29 @@ defmodule TimeZoneDatabaseTest do
     assert {:ok, datetime} = result
   end
 
+  test "lmt no longitude" do
+    naive_date_time = ~N[0100-01-01 00:00:00]
+    time_zone = "Europe/Brussels"
+
+    result = DateTime.from_naive(naive_date_time, time_zone, Tz.TimeZoneDatabase)
+
+    assert {:ok, datetime} = result
+    assert datetime.zone_abbr == "LMT"
+    assert datetime == DateTime.add(datetime, -86400, :second, Tz.TimeZoneDatabase) |> DateTime.add(86400, :second, Tz.TimeZoneDatabase)
+  end
+
+  test "lmt with longitude" do
+    naive_date_time = ~N[0100-01-01 00:00:00]
+    time_zone = "Europe/Brussels|-13"
+
+    result = DateTime.from_naive(naive_date_time, time_zone, Tz.TimeZoneDatabase)
+
+    assert {:ok, datetime} = result
+    assert datetime.zone_abbr == "LMT"
+    assert datetime.utc_offset == -3120
+    assert datetime == DateTime.add(datetime, -86400, :second, Tz.TimeZoneDatabase) |> DateTime.add(86400, :second, Tz.TimeZoneDatabase)
+  end
+
   test "version" do
     assert "2020f" == Tz.version()
   end


### PR DESCRIPTION
Thanks for the library. I've been using this patch for over 6 months for LMT by overloading the timezone with the longitude. 

A timezone of "Europe/Brussels" would then become "Europe/Brussels|-13". 

If the timezone returned is LMT and the longitude exists, we adjust the timezone offset appropriately accounting for the longitude.
