### PR TITLE
Fix IanaDataDir.maybe_copy_iana_files_to_custom_dir() crashing

### DIFF
--- a/lib/iana_data_dir.ex
+++ b/lib/iana_data_dir.ex
@@ -1,10 +1,9 @@
 defmodule Tz.IanaDataDir do
-  @dir Application.get_env(:tz, :data_dir, :code.priv_dir(:tz))
   @regex_tzdata_dir_name ~r/^tzdata20[0-9]{2}[a-z]$/
 
-  def dir_path(), do: @dir
+  defp dir, do: Application.get_env(:tz, :data_dir, :code.priv_dir(:tz))
 
-  def tzdata_dir_name(parent_dir \\ @dir) do
+  def tzdata_dir_name(parent_dir \\ dir()) do
     tz_data_dirs =
       File.ls!(parent_dir)
       |> Enum.filter(&Regex.match?(@regex_tzdata_dir_name, &1))
@@ -18,7 +17,7 @@ defmodule Tz.IanaDataDir do
 
   def tzdata_dir_path() do
     if dir_name = tzdata_dir_name() do
-      Path.join(@dir, dir_name)
+      Path.join(dir(), dir_name)
     end
   end
 
@@ -34,12 +33,12 @@ defmodule Tz.IanaDataDir do
       tzdata_version() ->
         nil
 
-      :code.priv_dir(:tz) == @dir ->
+      :code.priv_dir(:tz) == dir() ->
         raise "tzdata files not found"
 
       true ->
         if dir_name = tzdata_dir_name(:code.priv_dir(:tz)) do
-          File.cp_r!(Path.join(:code.priv_dir(:tz), dir_name), Path.join(@dir, dir_name))
+          File.cp_r!(Path.join(:code.priv_dir(:tz), dir_name), Path.join(dir(), dir_name))
         else
           raise "tzdata files not found"
         end
@@ -47,7 +46,7 @@ defmodule Tz.IanaDataDir do
   end
 
   def extract_tzdata_into_dir(version, content) do
-    tmp_archive_path = Path.join(@dir, "tzdata#{version}.tar.gz")
+    tmp_archive_path = Path.join(dir(), "tzdata#{version}.tar.gz")
     tzdata_dir_name = "tzdata#{version}"
     :ok = File.write!(tmp_archive_path, content)
 
@@ -64,9 +63,10 @@ defmodule Tz.IanaDataDir do
       'iso3166.tab',
       'zone1970.tab'
     ]
+
     :ok = :erl_tar.extract(tmp_archive_path, [
       :compressed,
-      {:cwd, Path.join(@dir, tzdata_dir_name)},
+      {:cwd, Path.join(dir(), tzdata_dir_name)},
       {:files, files_to_extract}
     ])
 
@@ -74,7 +74,7 @@ defmodule Tz.IanaDataDir do
   end
 
   def delete_tzdata_dir(version) do
-    Path.join(@dir, "tzdata#{version}")
+    Path.join(dir(), "tzdata#{version}")
     |> File.rm_rf!()
   end
 end


### PR DESCRIPTION
…in a release caused by `:code.priv_dir(:tz)` returning `_build/prod/lib/tz/priv` during compile time but it's actually located at `_build/prod/lib/tz-0.17.0/priv` in a release.