### PR TITLE
Add default Mint HTTP client options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.25.x
 
+* Add custom options for default Mint HTTP client.
 * Fix the bug that occurs when the maximum available year in an IANA rule exceeds
   the limit set by the 'max' rule (happened for Palestine).
 
@@ -20,6 +21,7 @@
     `:build_dst_periods_until_year`
 
 * Add a mix task to download the IANA time zone data for a given version
+
 ## 0.22.x
 
 * Add a mix task to download the IANA time zone data for a given version

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ module can, by default, only operate on datetimes in the UTC time zone. Alternat
 third-party libraries, such as `tz`, to bring in time zone support and deal with datetimes in other time zones than UTC.
 
 The `tz` library relies on the [time zone database](https://data.iana.org/time-zones/tzdb/) maintained by
-[IANA](https://www.iana.org). As of version 0.25.0, `tz` uses version **tzdata2023a** of the IANA time zone database.
+[IANA](https://www.iana.org). As of version 0.25.1, `tz` uses version **tzdata2023a** of the IANA time zone database.
 
 * [Installation and usage](#installation-and-usage)
 * [Core principles](#core-principles)
@@ -32,7 +32,7 @@ Add `tz` for Elixir as a dependency in your `mix.exs` file:
 ```elixir
 def deps do
   [
-    {:tz, "~> 0.25.0"}
+    {:tz, "~> 0.25.1"}
   ]
 end
 ```
@@ -173,7 +173,7 @@ defp deps do
   [
     {:castore, "~> 0.1"},
     {:mint, "~> 1.4"},
-    {:tz, "~> 0.25.0"}
+    {:tz, "~> 0.25.1"}
   ]
 end
 ```

--- a/README.md
+++ b/README.md
@@ -178,6 +178,13 @@ defp deps do
 end
 ```
 
+You may also add custom [options](https://hexdocs.pm/mint/Mint.HTTP.html#connect/4-options) for the http client `mint`:
+
+```elixir
+config :tz, Tz.HTTP.Mint.HTTPClient,
+  proxy: {:http, proxy_host, proxy_port, []}
+```
+
 ## Custom HTTP client
 
 You may implement the `Tz.HTTP.HTTPClient` behaviour in order to use another HTTP client.

--- a/lib/tz/compiler_runner.ex
+++ b/lib/tz/compiler_runner.ex
@@ -9,7 +9,8 @@ defmodule Tz.CompilerRunner do
       :data_dir,
       :iana_version,
       :build_dst_periods_until_year,
-      :reject_periods_before_year
+      :reject_periods_before_year,
+      Tz.HTTP.Mint.HTTPClient
     ]
 
   unknown_env_keys =

--- a/lib/tz/http/mint/http_client.ex
+++ b/lib/tz/http/mint/http_client.ex
@@ -10,7 +10,9 @@ if Code.ensure_loaded?(Mint.HTTP) do
 
     @impl Tz.HTTP.HTTPClient
     def request(hostname, path) do
-      {:ok, conn} = HTTP.connect(:https, hostname, 443)
+      opts = Application.get_env(:tz, Tz.HTTP.Mint.HTTPClient, [])
+
+      {:ok, conn} = HTTP.connect(:https, hostname, 443, opts)
       {:ok, conn, _} = HTTP.request(conn, "GET", path, [], nil)
 
       {:ok, response = %MintHTTPResponse{}} = recv_response(conn)

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Tz.MixProject do
   use Mix.Project
 
-  @version "0.25.0"
+  @version "0.25.1"
 
   def project do
     [


### PR DESCRIPTION
Aims to add a way to pass custom options to the default Mint HTTP client by adding a new config to the particular Mint implementation: `Tz.HTTP.Mint.HTTPClient`.

This would be particularly useful when one still wants to use the default client, but have to use a proxy to request timezones, for example (our use case).