### PR TITLE
fix: DateTime.add/3 `:nanosecond` precision error

### DIFF
--- a/lib/tz/time_zone_database.ex
+++ b/lib/tz/time_zone_database.ex
@@ -132,13 +132,9 @@ defmodule Tz.TimeZoneDatabase do
     |> Tz.PeriodsBuilder.periods_to_tuples_and_reverse()
   end
 
-  defp iso_days_to_gregorian_seconds({days, {parts_in_day, 86_400_000_000}}) do
-    div(days * 86_400_000_000 + parts_in_day, 1_000_000)
-  end
-
-  # Handles nanoseconds precision (86,400,000,000,000 nanoseconds in a day)
-  defp iso_days_to_gregorian_seconds({days, {parts_in_day, 86_400_000_000_000}}) do
-    div(days * 86_400_000_000_000 + parts_in_day, 1_000_000_000)
+  defp iso_days_to_gregorian_seconds({days, {parts_in_day, unit_in_day}}) do
+    units_per_second = div(unit_in_day, 86_400)
+    div(days * unit_in_day + parts_in_day, units_per_second)
   end
 
   defp naive_datetime_to_gregorian_seconds(%{calendar: Calendar.ISO, year: year}) when year < 0,

--- a/lib/tz/time_zone_database.ex
+++ b/lib/tz/time_zone_database.ex
@@ -136,6 +136,11 @@ defmodule Tz.TimeZoneDatabase do
     div(days * 86_400_000_000 + parts_in_day, 1_000_000)
   end
 
+  # Handles nanoseconds precision (86,400,000,000,000 nanoseconds in a day)
+  defp iso_days_to_gregorian_seconds({days, {parts_in_day, 86_400_000_000_000}}) do
+    div(days * 86_400_000_000_000 + parts_in_day, 1_000_000_000)
+  end
+
   defp naive_datetime_to_gregorian_seconds(%{calendar: Calendar.ISO, year: year}) when year < 0,
     do: 0
 

--- a/test/time_zone_database_test.exs
+++ b/test/time_zone_database_test.exs
@@ -171,6 +171,13 @@ defmodule TimeZoneDatabaseTest do
     assert DateTime.to_iso8601(datetime) == "2030-01-01T00:00:00+00:00"
   end
 
+  test "supports nanoseconds precision" do
+    date_time_utc = ~U[2029-12-31 10:15:00.000000Z]
+
+    assert ~U[2029-12-31 10:15:00.000001Z] ==
+             DateTime.add(date_time_utc, 1_000, :nanosecond, Tz.TimeZoneDatabase)
+  end
+
   test "next_period/1" do
     {:ok, dt} =
       DateTime.new(~D[2030-09-01], ~T[10:00:00], "Europe/Copenhagen", Tz.TimeZoneDatabase)


### PR DESCRIPTION
Steps to reproduce:

```elixir
DateTime.add(DateTime.utc_now(), 1_000, :nanosecond, Tz.TimeZoneDatabase)
```

(added a test that reproduces it)