### PR TITLE
Remove unneeded import/require.

### DIFF
--- a/lib/tz/compiler.ex
+++ b/lib/tz/compiler.ex
@@ -1,10 +1,6 @@
 defmodule Tz.Compiler do
   @moduledoc false
 
-  require Logger
-  require Tz.IanaFileParser
-  require Tz.PeriodsBuilder
-
   alias Tz.IanaDataDir
   alias Tz.IanaFileParser
   alias Tz.PeriodsBuilder


### PR DESCRIPTION
Small, cosmetical, it removes warnings where elixir 1.20 is a bit louder.
So, users of this library when changing to elixir-1.20 do not have to switch off `--warnings-as-errors` for `mix`.

```
Compiling 16 files (.ex)
    warning: unused require Logger
    │
  4 │   require Logger
    │   ~
    │
    └─ lib/tz/compiler.ex:4:3

    warning: unused require Tz.IanaFileParser
    │
  5 │   require Tz.IanaFileParser
    │   ~
    │
    └─ lib/tz/compiler.ex:5:3

    warning: unused require Tz.PeriodsBuilder
    │
  6 │   require Tz.PeriodsBuilder
    │   ~
    │
    └─ lib/tz/compiler.ex:6:3
```